### PR TITLE
Search from path 274

### DIFF
--- a/qucs/main.cpp
+++ b/qucs/main.cpp
@@ -130,14 +130,10 @@ bool loadSettings()
     if(settings.contains("NgspiceExecutable")) QucsSettings.NgspiceExecutable = settings.value("NgspiceExecutable").toString();
     else {
 #ifdef Q_OS_WIN
-        QString ngsp_base = "ngspice_con";
+        QucsSettings.NgspiceExecutable = "ngspice_con.exe";
 #else
-        QString ngsp_base = "ngspice";
+        QucsSettings.NgspiceExecutable = "ngspice";
 #endif
-        QString ngsp_exe = QCoreApplication::applicationDirPath() +
-                QDir::separator() + ngsp_base + executableSuffix;
-        if (!QFile::exists(ngsp_exe)) ngsp_exe = QString("ngspice") + executableSuffix;
-        QucsSettings.NgspiceExecutable = ngsp_exe;
     }
     if(settings.contains("XyceExecutable")) QucsSettings.XyceExecutable = settings.value("XyceExecutable").toString();
     else {

--- a/qucs/misc.cpp
+++ b/qucs/misc.cpp
@@ -618,6 +618,44 @@ QString misc::wildcardToRegularExpression(const QString &wc_str, const bool enab
     return rx;
 }
 
+bool misc::simulatorExisits(const QString &exe_file)
+{
+    if (QFile::exists(exe_file)) return true; // absolute path
+
+    QFileInfo inf(exe_file); // try to find exe in $PATH
+    char *p = getenv("PATH");
+    QStringList paths;
+    bool found = false;
+    if (p != nullptr) paths = QString(p).split(':');
+    for (const auto &pp : paths) {
+        inf.setFile(pp + QDir::separator() + exe_file);
+        if (inf.exists()) {
+            found = true;
+            break;
+        }
+    }
+    return found;
+}
+
+QString misc::unwrapExePath(const QString &exe_file)
+{
+    if (QFile::exists(exe_file)) return exe_file; // absolute path
+
+    QFileInfo inf(exe_file); // try to find exe in $PATH
+    char *p = getenv("PATH");
+    QStringList paths;
+    QString abs_exe_path = exe_file;
+    if (p != nullptr) paths = QString(p).split(':');
+    for (const auto &pp : paths) {
+        inf.setFile(pp + QDir::separator() + exe_file);
+        if (inf.exists()) {
+            abs_exe_path = inf.canonicalFilePath();
+            break;
+        }
+    }
+    return abs_exe_path;
+}
+
 
 VersionTriplet::VersionTriplet(){
   major = minor = patch = 0;

--- a/qucs/misc.cpp
+++ b/qucs/misc.cpp
@@ -618,7 +618,7 @@ QString misc::wildcardToRegularExpression(const QString &wc_str, const bool enab
     return rx;
 }
 
-bool misc::simulatorExisits(const QString &exe_file)
+bool misc::simulatorExists(const QString &exe_file)
 {
     if (QFile::exists(exe_file)) return true; // absolute path
 

--- a/qucs/misc.h
+++ b/qucs/misc.h
@@ -94,7 +94,7 @@ namespace misc {
   bool isDarkTheme();
   QString wildcardToRegularExpression(const QString &wc_str, const bool enableEscaping);
 
-  bool simulatorExisits(const QString &exe_file);
+  bool simulatorExists(const QString &exe_file);
   QString unwrapExePath(const QString &exe_file);
 }
 

--- a/qucs/misc.h
+++ b/qucs/misc.h
@@ -93,6 +93,9 @@ namespace misc {
   QString getIconPath(const QString &file, int icon_type);
   bool isDarkTheme();
   QString wildcardToRegularExpression(const QString &wc_str, const bool enableEscaping);
+
+  bool simulatorExisits(const QString &exe_file);
+  QString unwrapExePath(const QString &exe_file);
 }
 
 /*! handle the application version string

--- a/qucs/qucs.cpp
+++ b/qucs/qucs.cpp
@@ -230,23 +230,24 @@ QucsApp::QucsApp()
 #endif
       ngspice_exe = QDir::toNativeSeparators(ngspice_exe);
       if (found) {
-//          QMessageBox::information(nullptr,tr("Set simulator"),
-//                                   tr("Ngspice found at: ") + ngspice_exe + "\n" +
-//                                   tr("You can specify another location later"
-//                                      " using Simulation->Select default simulator"));
+          QMessageBox::information(nullptr,tr("Set simulator"),
+                                   tr("Ngspice found at: ") + ngspice_exe + "\n" +
+                                   tr("You can specify another location later"
+                                      " using Simulation->Simulators Setings"));
           QucsSettings.DefaultSimulator = spicecompat::simNgspice;
           QucsSettings.NgspiceExecutable = ngspice_exe;
+          fillSimulatorsComboBox();
       }
   }
 
-//  if (QucsSettings.DefaultSimulator == spicecompat::simNotSpecified) {
-//      QMessageBox::information(this,tr("Qucs"),tr("Default simulator is not specified yet.\n"
-//                                         "Please setup it in the next dialog window.\n"
-//                                         "If you have no simulators except Qucs installed\n"
-//                                         "in your system leave default Qucsator setting\n"
-//                                         "and simple press Apply button"));
-//      slotSimSettings();
-//  }
+  if (QucsSettings.DefaultSimulator == spicecompat::simNotSpecified) {
+      QMessageBox::information(this,tr("Qucs"),tr("Default simulator is not specified yet.\n"
+                                         "Please setup it in the next dialog window.\n"
+                                         "If you have no simulators except Qucs installed\n"
+                                         "in your system leave default Qucsator setting\n"
+                                         "and simple press Apply button"));
+      slotSimSettings();
+  }
 //  fillLibrariesTreeView();
 }
 

--- a/qucs/qucs.cpp
+++ b/qucs/qucs.cpp
@@ -771,16 +771,20 @@ void QucsApp::fillSimulatorsComboBox() {
     simulatorsCombobox->clear();
     //simulatorsCombobox->addItem(spicecompat::getDefaultSimulatorName(spicecompat::simNotSpecified), 0);
 
-    if (QFile::exists(QucsSettings.NgspiceExecutable)) {
+    if (misc::simulatorExists(QucsSettings.NgspiceExecutable)) {
+        QucsSettings.NgspiceExecutable = misc::unwrapExePath(QucsSettings.NgspiceExecutable);
         simulatorsCombobox->addItem(spicecompat::getDefaultSimulatorName(spicecompat::simNgspice), 1);
     }
-    if (QFile::exists(QucsSettings.XyceExecutable)) {
+    if (misc::simulatorExists(QucsSettings.XyceExecutable)) {
+        QucsSettings.XyceExecutable = misc::unwrapExePath(QucsSettings.XyceExecutable);
         simulatorsCombobox->addItem(spicecompat::getDefaultSimulatorName(spicecompat::simXyce), 2);
     }
-    if (QFile::exists(QucsSettings.SpiceOpusExecutable)) {
+    if (misc::simulatorExists(QucsSettings.SpiceOpusExecutable)) {
+        QucsSettings.SpiceOpusExecutable = misc::unwrapExePath(QucsSettings.SpiceOpusExecutable);
         simulatorsCombobox->addItem(spicecompat::getDefaultSimulatorName(spicecompat::simSpiceOpus), 4);
     }
-    if (QFile::exists(QucsSettings.Qucsator)) {
+    if (misc::simulatorExists(QucsSettings.Qucsator)) {
+        QucsSettings.Qucsator = misc::unwrapExePath(QucsSettings.Qucsator);
         simulatorsCombobox->addItem(spicecompat::getDefaultSimulatorName(spicecompat::simQucsator), 8);
     }
 


### PR DESCRIPTION
This PR implements search for simulator in $PATH. Two related methods are added in `misc` namespace. The logic is following:

* Try to find existing executables in `fillSimulatorsComboBox` and expand the simulator paths if it is defined relatively using PATH. Only absolute paths are allowed. The definition using PATH is not allowed anymore.
* Try to find Ngspice executable in some usual installation places.
* If nothing found show simulator setup dialog and allow user to set the simulator location manually. 

I have tested both startup using config file from previous version and fresh startup without config file. Everything should work as expected.  